### PR TITLE
Update buttons.html

### DIFF
--- a/buttons.html
+++ b/buttons.html
@@ -1,89 +1,89 @@
 <html>
     <head>
-        <Title>Buttons</Title>
+        <title>Buttons</title>
     </head>
     <body>
         <style>
-        .uber-button {
-            background-color: black;
-            color: white;
-            height: 36px;
-            width: 120px;
-            border-radius: 2px;
-            border-style: solid;
-            cursor: pointer;
-            margin-right: 10px;
-            transition: opacity 0.15s;
-        }
-        .uber-button:hover {
-            opacity: 0.85;
-        }
-        .uber-button:active {
-            opacity: 0.6;
-        }
-        .amazon-button {
-            background-color: rgb(255,216,20);
-            color: black;
-            height: 36px;
-            width : 150;
-            border : none;
-            border-radius: 18px;
-            cursor: pointer;
-            margin-right: 10px;
-        }
-        .github-button {
-            background-color: rgb(46,164,79);
-            color: white;
-            height: 36px;
-            width : 80px;
-            border :none;
-            border-radius: 8px;
-            font-weight: bold;    
-            cursor: pointer;
-
-        }
-        .github-button:hover {
-            box-shadow: 0px 5px 5px rgba(0,0,0,0.15);
-        }
-     
-        .Bootstrap {
-            background-color: rgb(121,82,179);
-            color: white;
-            height: 36px;
-            width: 110px;
-            border: none;
-            border-radius: 5px;
-            font-weight: bold;
-            cursor: pointer;
-            margin-left: 10px;
-        }
-        .Bootstrap-download {
-            background-color: white;
-            color: rgb(108,117,125);
-            border-color: rgb(108,117,125);
-            border-radius: 5px;
-            font-weight: bold;
-            height: 36px;
-            width: 100px;
-            font-size: 12px;
-            cursor: pointer;
-            border-style: solid;
-            border-width: 1.5px;
-            margin-left: 5px;
-            margin-top: 5px;
-            align-items: center;
-            transition: background-color 0.15s,color 0.15s;
-
-        }
-        .Bootstrap-download:hover {
-            background-color: rgb(108,117,125);
-            color: white;
-        }
+            .uber-button {
+                background-color: black;
+                color: white;
+                height: 36px;
+                width: 120px;
+                border-radius: 2px;
+                border-style: solid;
+                cursor: pointer;
+                margin-right: 10px;
+                transition: opacity 0.15s;
+            }
+            .uber-button:hover {
+                opacity: 0.85;
+            }
+            .uber-button:active {
+                opacity: 0.6;
+            }
+            .amazon-button {
+                background-color: rgb(255, 216, 20);
+                color: black;
+                height: 36px;
+                width: 150px;
+                border: none;
+                border-radius: 18px;
+                cursor: pointer;
+                margin-right: 10px;
+            }
+            .github-button {
+                background-color: rgb(46, 164, 79);
+                color: white;
+                height: 36px;
+                width: 80px;
+                border: none;
+                border-radius: 8px;
+                font-weight: bold;
+                cursor: pointer;
+            }
+            .github-button:hover {
+                box-shadow: 0px 5px 5px rgba(0, 0, 0, 0.15);
+            }
+            .bootstrap-button {
+                background-color: rgb(121, 82, 179);
+                color: white;
+                height: 36px;
+                width: 110px;
+                border: none;
+                border-radius: 5px;
+                font-weight: bold;
+                cursor: pointer;
+                margin-left: 10px;
+            }
+            .bootstrap-download {
+                background-color: white;
+                color: rgb(108, 117, 125);
+                border-color: rgb(108, 117, 125);
+                border-radius: 5px;
+                font-weight: bold;
+                height: 36px;
+                width: 100px;
+                font-size: 12px;
+                cursor: pointer;
+                border-style: solid;
+                border-width: 1.5px;
+                margin-left: 5px;
+                margin-top: 5px;
+                align-items: center;
+                transition: background-color 0.15s, color 0.15s;
+            }
+            .bootstrap-download:hover {
+                background-color: rgb(108, 117, 125);
+                color: white;
+            }
         </style>
-    <button class="uber-button"><a href = "https://www.uber.com/in/en/ride/"; target="_blank">Request now</a></button>
-    <button class="amazon-button">Add to Cart</button>
-    <button class="github-button">Sign up</button>
-    <button class="Bootstrap">Get started</button>
-    <button class="Bootstrap-download">Download</button>
-</body>
+        
+        <button class="uber-button">
+            <a href="https://www.uber.com/in/en/ride/" target="_blank" style="color: white; text-decoration: none;">Request now</a>
+        </button>
+        <button class="amazon-button">Add to Cart</button>
+        <button class="github-button">Sign up</button>
+        <button class="bootstrap-button">Get started</button>
+        <button class="bootstrap-download">Download</button>
+    </body>
 </html>


### PR DESCRIPTION
In the href attribute of the anchor tag (<a>), remove the unnecessary semicolon (;). It's not needed in HTML attributes. The amazon-button class is missing the px unit for the width. Add px to specify the unit for better clarity and consistency.

The <a> tag should be inside the button if you want the entire button to be clickable. If the <a> is outside, only the text inside the <a> tag will be clickable, which might not be the intended design. If you want the buttons to be more consistent in alignment, you might want to wrap all of them with a container and apply consistent padding or margin to align them properly.